### PR TITLE
add: buildContextMessages

### DIFF
--- a/src/main/java/dku25/chatGraph/api/controller/OpenaiController.java
+++ b/src/main/java/dku25/chatGraph/api/controller/OpenaiController.java
@@ -4,16 +4,14 @@ import dku25.chatGraph.api.openai.service.OpenaiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
 
 @RestController
 public class OpenaiController {
+
     private final Logger logger = LoggerFactory.getLogger(OpenaiController.class);
     private final OpenaiService openaiService;
 
@@ -30,21 +28,19 @@ public class OpenaiController {
     }
 
     @PostMapping("/ask-context")
-    public Mono<String> askWithContext(@RequestParam String sessionId, @RequestBody Map<String, String> payload) {
+    public Mono<String> askWithContext(@RequestParam String sessionId,
+                                       @RequestBody Map<String, String> payload) {
+
         String prompt = payload.get("prompt");
         String previousQuestionId = payload.get("previousQuestionId");
         logger.info("/ask-context 요청 - 세션 ID: {}, 질문: {}, 이전 질문ID: {}", sessionId, prompt, previousQuestionId);
 
-        if (prompt == null || prompt.isEmpty()) {
+        if (prompt == null || prompt.trim().isEmpty()) {
             logger.warn("/ask-context 요청 - 질문이 비어 있습니다.");
             return Mono.just("질문을 입력해주세요.");
         }
-        if (previousQuestionId != null && !previousQuestionId.isEmpty()) {
-            return openaiService.askWithContext(sessionId, prompt,  previousQuestionId)
-                    .doOnSuccess(answer -> logger.info("/ask-context 응답 - 세션 ID: {}, 답변: {}", sessionId, answer));
-        }
 
-        return openaiService.askWithContext(sessionId, prompt)
+        return openaiService.askWithContext(sessionId, prompt, previousQuestionId)
                 .doOnSuccess(answer -> logger.info("/ask-context 응답 - 세션 ID: {}, 답변: {}", sessionId, answer));
     }
 }

--- a/src/main/java/dku25/chatGraph/api/graph/node/QuestionNode.java
+++ b/src/main/java/dku25/chatGraph/api/graph/node/QuestionNode.java
@@ -17,7 +17,6 @@ public class QuestionNode extends DefaultNode {
     @Setter(AccessLevel.NONE)
     private String questionId;
     private String text;
-    private String sessionId;
     private int level;
 
     @Relationship(type = "HAS_ANSWER", direction = Relationship.Direction.OUTGOING)
@@ -29,11 +28,10 @@ public class QuestionNode extends DefaultNode {
     @Relationship(type = "PREVIOUS_QUESTION", direction = Relationship.Direction.OUTGOING)
     private QuestionNode previousQuestion;
 
-    public static QuestionNode createQuestion(String text, String sessionId, QuestionNode previousQuestion) {
+    public static QuestionNode createQuestion(String text, QuestionNode previousQuestion) {
         QuestionNode questionNode = QuestionNode.builder()
                 .questionId("question-" + UUID.randomUUID())
                 .text(text)
-                .sessionId(sessionId)
                 .build();
 
         questionNode.setPreviousQuestion(previousQuestion);

--- a/src/main/java/dku25/chatGraph/api/graph/node/TopicNode.java
+++ b/src/main/java/dku25/chatGraph/api/graph/node/TopicNode.java
@@ -22,7 +22,7 @@ public class TopicNode extends DefaultNode {
     private String topicName;
     private String sessionId;
 
-    @Relationship(type="start_conversation", direction = Relationship.Direction.OUTGOING)
+    @Relationship(type = "start_conversation", direction = Relationship.Direction.OUTGOING)
     private QuestionNode firstQuestion;
 
     public static TopicNode createTopic(String topicName, String sessionId) {

--- a/src/main/java/dku25/chatGraph/api/graph/service/GraphService.java
+++ b/src/main/java/dku25/chatGraph/api/graph/service/GraphService.java
@@ -2,8 +2,10 @@ package dku25.chatGraph.api.graph.service;
 
 import dku25.chatGraph.api.graph.node.AnswerNode;
 import dku25.chatGraph.api.graph.node.QuestionNode;
+import dku25.chatGraph.api.graph.node.TopicNode;
 import dku25.chatGraph.api.graph.repository.AnswerRepository;
 import dku25.chatGraph.api.graph.repository.QuestionRepository;
+import dku25.chatGraph.api.graph.repository.TopicRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -12,36 +14,47 @@ import java.util.Optional;
 @Service
 public class GraphService {
 
-    private final AnswerRepository answerRepository;
+    private final TopicRepository topicRepository;
     private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
 
     @Autowired
-    public GraphService(AnswerRepository answerRepository, QuestionRepository questionRepository) {
-        this.answerRepository = answerRepository;
+    public GraphService(TopicRepository topicRepository, QuestionRepository questionRepository, AnswerRepository answerRepository) {
+        this.topicRepository = topicRepository;
         this.questionRepository = questionRepository;
+        this.answerRepository = answerRepository;
     }
 
-    public void saveToNeo4j(String sessionId, String prompt, String answer, Optional<QuestionNode> previousQuestionOpt) {
-        AnswerNode answerNode = AnswerNode.createAnswer(answer);
-        answerRepository.save(answerNode);
+    public void saveFirstQuestion(String prompt, String sessionId, String answer) {
+        QuestionNode firstQuestion = createAndSaveQuestion(prompt, answer, null);
 
-        QuestionNode previousQuestion = previousQuestionOpt.orElse(null);
-        QuestionNode currentQuestion = QuestionNode.createQuestion(prompt, sessionId, previousQuestion);
-        currentQuestion.setAnswer(answerNode);
-
-        if (previousQuestion != null) {
-            previousQuestion.setFollowedBy(currentQuestion);
-        }
-
-        questionRepository.save(currentQuestion);
+        TopicNode topic = TopicNode.createTopic("New Chat", sessionId);
+        topic.setFirstQuestion(firstQuestion);
+        topicRepository.save(topic);
     }
 
-    public void saveToNeo4j(String sessionId, String prompt, String answer) {
-        saveToNeo4j(sessionId, prompt, answer, Optional.empty());
+    public void saveFollowUpQuestion(String prompt, String sessionId, String answer, String previousQuestionId) {
+        QuestionNode previousQuestion = questionRepository.findById(previousQuestionId).orElseThrow(() -> new IllegalArgumentException("이전 질문이 없습니다."));
+        createAndSaveQuestion(prompt, answer, previousQuestion);
     }
 
     public Optional<QuestionNode> findQuestionById(String id){
         return questionRepository.findById(id);
+    }
+
+    private QuestionNode createAndSaveQuestion(String prompt, String answer, QuestionNode previousQuestion) {
+        AnswerNode answerNode = AnswerNode.createAnswer(answer);
+        answerRepository.save(answerNode);
+
+        QuestionNode currentQuestion = QuestionNode.createQuestion(prompt, previousQuestion);
+        currentQuestion.setAnswer(answerNode);
+
+        if (previousQuestion != null) {
+            previousQuestion.setFollowedBy(currentQuestion);
+            questionRepository.save(previousQuestion);
+        }
+
+        return questionRepository.save(currentQuestion);
     }
 }
 

--- a/src/main/java/dku25/chatGraph/api/openai/model/ChatCompletionResponse.java
+++ b/src/main/java/dku25/chatGraph/api/openai/model/ChatCompletionResponse.java
@@ -15,4 +15,11 @@ public class ChatCompletionResponse {
     private String model;
     private List<Choice> choices;
     private Usage usage;
+
+    public String getFirstAnswerContent() {
+        if (choices != null && !choices.isEmpty()) {
+            return choices.get(0).getMessage().getContent();
+        }
+        return "";
+    }
 }

--- a/src/main/java/dku25/chatGraph/api/openai/service/OpenaiService.java
+++ b/src/main/java/dku25/chatGraph/api/openai/service/OpenaiService.java
@@ -1,18 +1,13 @@
 package dku25.chatGraph.api.openai.service;
 
-import dku25.chatGraph.api.graph.node.AnswerNode;
-import dku25.chatGraph.api.graph.repository.AnswerRepository;
 import dku25.chatGraph.api.graph.node.QuestionNode;
-import dku25.chatGraph.api.graph.repository.QuestionRepository;
 import dku25.chatGraph.api.graph.service.GraphService;
 import dku25.chatGraph.api.openai.model.ChatCompletionRequest;
 import dku25.chatGraph.api.openai.model.ChatCompletionResponse;
 import dku25.chatGraph.api.openai.model.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -21,15 +16,16 @@ import java.util.*;
 
 @Service
 public class OpenaiService {
+
     private final Logger logger = LoggerFactory.getLogger(OpenaiService.class);
     private final WebClient openaiWebClient;
     private final String defaultOpenaiModel;
     private final GraphService graphService;
-    private final Map<String, List<Message>> conversationHistory = new HashMap<>(); // 세션별 대화 기록 저장소
 
     @Autowired
     public OpenaiService(@Qualifier("openaiWebClient") WebClient openaiWebClient,
-                         @Value("${openai.model.default}") String defaultOpenaiModel, GraphService graphService) {
+                         @Value("${openai.model.default}") String defaultOpenaiModel,
+                         GraphService graphService) {
         this.openaiWebClient = openaiWebClient;
         this.defaultOpenaiModel = defaultOpenaiModel;
         this.graphService = graphService;
@@ -37,47 +33,41 @@ public class OpenaiService {
 
     public String startNewChat() {
         String sessionId = UUID.randomUUID().toString();
-        conversationHistory.put(sessionId, new ArrayList<>());
         logger.info("새로운 채팅 세션 시작: {}", sessionId);
         return sessionId;
     }
 
-    public Mono<String> askWithContext(String sessionId, String prompt) {
-        return askWithOptionalPrevious(sessionId, prompt, Optional.empty());
-    }
-
     public Mono<String> askWithContext(String sessionId, String prompt, String previousQuestionId) {
-        Optional<QuestionNode> previous = graphService.findQuestionById(previousQuestionId);
-        return askWithOptionalPrevious(sessionId, prompt, previous);
-    }
+        List<Message> contextMessages = new ArrayList<>();
 
-    public Mono<String> askWithOptionalPrevious(String sessionId, String prompt, Optional<QuestionNode> previousOpt) {
-        List<Message> messages = conversationHistory.computeIfAbsent(sessionId, k -> new ArrayList<>());
-        messages.add(new Message("user", prompt));
-        logger.info("세션 {} 에 새 질문 추가: {}", sessionId, prompt);
+        if (previousQuestionId != null && !previousQuestionId.isEmpty()) {
+            Optional<QuestionNode> prevQuestionNodeOpt = graphService.findQuestionById(previousQuestionId);
+            prevQuestionNodeOpt.ifPresent(prevQuestionNode -> contextMessages.addAll(buildContextMessages(prevQuestionNode)));
+        }
 
-        return getChatCompletion(messages)
+        contextMessages.add(new Message("user", prompt));
+
+        return getChatCompletion(contextMessages)
                 .map(response -> {
-                    if (response != null && response.getChoices() != null && !response.getChoices().isEmpty()) {
-                        String answer = response.getChoices().get(0).getMessage().getContent();
-                        messages.add(new Message("assistant", answer)); // 답변을 대화 기록에 추가
-                        logger.info("세션 {} 에 답변 추가: {}", sessionId, answer);
-                        graphService.saveToNeo4j(sessionId, prompt, answer, previousOpt);
-                        return answer;
+                    String answer = response.getFirstAnswerContent();
+                    logger.info("응답 저장 - 세션 ID: {}, 답변: {}", sessionId, answer);
+
+                    if (previousQuestionId != null && !previousQuestionId.isEmpty()) {
+                        graphService.saveFollowUpQuestion(prompt, sessionId, answer, previousQuestionId);
                     } else {
-                        String errorMessage = "OpenAI API 응답이 비었습니다.";
-                        logger.warn(errorMessage);
-                        return errorMessage;
+                        graphService.saveFirstQuestion(prompt, sessionId, answer);
                     }
+
+                    return answer;
                 })
                 .onErrorResume(e -> {
-                    logger.error("세션 {} 맥락 유지 요청 중 오류 발생: {}", sessionId, e.getMessage());
-                    return Mono.just("맥락 유지 요청 중 오류 발생: " + e.getMessage());
+                    logger.error("OpenAI 요청 실패: {}", e.getMessage());
+                    return Mono.just("오류가 발생했습니다: " + e.getMessage());
                 });
     }
 
     public Mono<ChatCompletionResponse> getChatCompletion(List<Message> messages) {
-        return getChatCompletion(messages, this.defaultOpenaiModel);
+        return getChatCompletion(messages, defaultOpenaiModel);
     }
 
     public Mono<ChatCompletionResponse> getChatCompletion(List<Message> messages, String model) {
@@ -89,8 +79,25 @@ public class OpenaiService {
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(ChatCompletionResponse.class)
-                .doOnSuccess(response -> logger.info("OpenAI API 응답: {}", response))
-                .doOnError(error -> logger.error("OpenAI API 요청 실패: {}", error.getMessage()));
+                .doOnSuccess(response -> logger.info("OpenAI 응답 성공"))
+                .doOnError(error -> logger.error("OpenAI 응답 실패: {}", error.getMessage()));
     }
 
+    public List<Message> buildContextMessages(QuestionNode prevQuestionNode) {
+        List<Message> messages = new ArrayList<>();
+        QuestionNode cursor = prevQuestionNode;
+        int cursorLevel = prevQuestionNode.getLevel();
+
+        int targetLevel = Math.max(1, cursorLevel - 2);
+
+        while (cursor != null && cursor.getLevel() >= targetLevel) {
+            if (cursor.getAnswer() != null) {
+                messages.add(0, new Message("assistant", cursor.getAnswer().getText()));
+            }
+            messages.add(0, new Message("user", cursor.getText()));
+            cursor = cursor.getPreviousQuestion();
+        }
+
+        return messages;
+    }
 }


### PR DESCRIPTION
## TopicNode
Topic 추가로 인해 문답 생성 시

첫 질문일 경우 Topic 생성

Topic에는 SessionId(UserId), TopicName이 존재.

TopicName은 기본적으로 "New Chat" 으로 Default로 생성.

## 문맥유지 방법 변경
OpenaiController 클래스 -> askWithContext 에서

원래의 방법은 로컬 HashMap을 통해서 그동안의 요청 및 응답을 저장해서 문맥유지에 사용했음.

=> 현재 방법은 neo4j 노드 내에 문답 데이터가 노드로써 존재하기에.

문맥유지를 위해서 새로운 질문을 요청 시 
1. previousQuestionId 값이 없을 경우.
-> 문맥유지 필요 없음.

2. previousQuestionId 값이 있을 경우. 최대 상위 3단계의 문답 노드 탐색.
-> 문맥 유지를 위해 previousQuestionId 값을 통해 직전 질문의 level 탐색.
-> 직전 질문의 level을 통해서 최대 상위 3단계의 문답 노드 탐색. (이는 유동적으로 변경 가능)

=> 문맥 유지에 있어서 토큰 절약 및 조금 더 유연함. 또한 로컬에 의지하지 않기에 이제는 서버가 리부팅되어도 문맥 유지 가능.